### PR TITLE
Fix missing braces in CrashLogStore

### DIFF
--- a/R3P.Hivemind.Core/Diagnostics/CrashLogStore.cs
+++ b/R3P.Hivemind.Core/Diagnostics/CrashLogStore.cs
@@ -46,7 +46,7 @@ namespace R3P.Hivemind.Core.Diagnostics
             }
             var handler = LineAppended;
             handler?.Invoke(null, message);
+        }
     }
 }
-
 


### PR DESCRIPTION
## Summary
- add the missing closing braces to CrashLogStore so the append method, class, and namespace compile again

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcfe2f8b8832cb7f4ba2c63ea0c1b