### PR TITLE
Move conduit services to shared core

### DIFF
--- a/R3P.Conduit/src/Features/Conduit/ConduitCommands.cs
+++ b/R3P.Conduit/src/Features/Conduit/ConduitCommands.cs
@@ -9,9 +9,11 @@ using Autodesk.AutoCAD.Runtime;
 using Autodesk.AutoCAD.Windows;
 using AcadApp = Autodesk.AutoCAD.ApplicationServices.Application;
 using Microsoft.Win32;
+using R3P.Hivemind.Core.Diagnostics;
+using R3P.Hivemind.Core.Features.Conduit.Model;
+using R3P.Hivemind.Core.Features.Conduit.Services;
 using R3P.Hivemind.Services;
 using R3P.Hivemind.UI.Wpf;
-using R3P.Hivemind.Core.Diagnostics;
 
 namespace R3P.Hivemind.Features.Conduit
 {
@@ -89,7 +91,7 @@ namespace R3P.Hivemind.Features.Conduit
             }
         }
 
-        internal static void UiPlaceTagForSelected(Model.ConduitItem selected)
+        internal static void UiPlaceTagForSelected(ConduitItem selected)
         {
             if (selected == null) return;
             var doc = AcadApp.DocumentManager.MdiActiveDocument; var ed = doc.Editor; var db = doc.Database;
@@ -112,7 +114,7 @@ namespace R3P.Hivemind.Features.Conduit
             }
         }
 
-        internal static void UiRemoveTag(Model.ConduitItem selected)
+        internal static void UiRemoveTag(ConduitItem selected)
         {
             if (selected == null) return;
             var doc = AcadApp.DocumentManager.MdiActiveDocument; var db = doc.Database;
@@ -189,10 +191,10 @@ namespace R3P.Hivemind.Features.Conduit
         }
 
         // ---- Query ----
-        public static List<Model.ConduitItem> GetAllItems()
+        public static List<ConduitItem> GetAllItems()
         {
-            var doc = AcadApp.DocumentManager.MdiActiveDocument; if (doc == null) return new List<Model.ConduitItem>();
-            var ed = doc.Editor; var db = doc.Database; var items = new List<Model.ConduitItem>();
+            var doc = AcadApp.DocumentManager.MdiActiveDocument; if (doc == null) return new List<ConduitItem>();
+            var ed = doc.Editor; var db = doc.Database; var items = new List<ConduitItem>();
             var filter = new SelectionFilter(new[] { new TypedValue((int)DxfCode.Start, "LINE,ARC,LWPOLYLINE,POLYLINE,SPLINE,ELLIPSE") });
             var psr = ed.SelectAll(filter); if (psr.Status != PromptStatus.OK) return items;
             using (var tr = db.TransactionManager.StartTransaction())
@@ -208,7 +210,7 @@ namespace R3P.Hivemind.Features.Conduit
                         var feet = Utils.ToFeet(adj);
                         var cfg = ConfigService.Get(db);
                         if (feet > cfg.FiberThresholdFt) hint = $"> {cfg.FiberThresholdFt:0} ft — fiber recommended";
-                        items.Add(new Model.ConduitItem { Id = ent.ObjectId, Handle = h, Tag = tag, Raw = raw, Adjusted = adj, FtIn = ftin, Hint = hint });
+                        items.Add(new ConduitItem { Id = ent.ObjectId, Handle = h, Tag = tag, Raw = raw, Adjusted = adj, FtIn = ftin, Hint = hint });
                     }
                 }
                 tr.Commit();

--- a/R3P.Conduit/src/Features/Conduit/UI/Wpf/ConduitManagerView.xaml.cs
+++ b/R3P.Conduit/src/Features/Conduit/UI/Wpf/ConduitManagerView.xaml.cs
@@ -2,7 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
-using R3P.Hivemind.Features.Conduit.Model;
+using R3P.Hivemind.Core.Features.Conduit.Model;
+using R3P.Hivemind.Core.Features.Conduit.Services;
 using R3P.Hivemind.Services;
 
 namespace R3P.Hivemind.Features.Conduit.UI.Wpf

--- a/R3P.Hivemind.Core/Features/Conduit/Model/ConduitItem.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Model/ConduitItem.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using Autodesk.AutoCAD.DatabaseServices;
 
-namespace R3P.Hivemind.Features.Conduit.Model
+namespace R3P.Hivemind.Core.Features.Conduit.Model
 {
     public class ConduitItem
     {

--- a/R3P.Hivemind.Core/Features/Conduit/Services/ConfigService.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Services/ConfigService.cs
@@ -1,9 +1,9 @@
 using System;
 using Autodesk.AutoCAD.DatabaseServices;
 
-namespace R3P.Hivemind.Features.Conduit.Services
+namespace R3P.Hivemind.Core.Features.Conduit.Services
 {
-    internal static class ConfigService
+    public static class ConfigService
     {
         public class Config {
             public string Prefix = "P-";

--- a/R3P.Hivemind.Core/Features/Conduit/Services/DataService.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Services/DataService.cs
@@ -1,9 +1,9 @@
 using System;
 using Autodesk.AutoCAD.DatabaseServices;
 
-namespace R3P.Hivemind.Features.Conduit.Services
+namespace R3P.Hivemind.Core.Features.Conduit.Services
 {
-    internal static class DataService
+    public static class DataService
     {
         private const string ExtKey = "R3P_CONDUIT";
 

--- a/R3P.Hivemind.Core/Features/Conduit/Services/ExcelService.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Services/ExcelService.cs
@@ -4,11 +4,11 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Windows;
-using R3P.Hivemind.Features.Conduit.Model;
+using R3P.Hivemind.Core.Features.Conduit.Model;
 
-namespace R3P.Hivemind.Features.Conduit.Services
+namespace R3P.Hivemind.Core.Features.Conduit.Services
 {
-    internal static class ExcelService
+    public static class ExcelService
     {
         public static void ExportCsv(List<ConduitItem> items, string fileName)
         {

--- a/R3P.Hivemind.Core/Features/Conduit/Services/Geometry.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Services/Geometry.cs
@@ -1,9 +1,9 @@
 using System;
 using Autodesk.AutoCAD.Geometry;
 
-namespace R3P.Hivemind.Features.Conduit.Services
+namespace R3P.Hivemind.Core.Features.Conduit.Services
 {
-    internal static class Geometry
+    public static class Geometry
     {
         public static Extents3d Expand(Extents3d e, double d)
         {

--- a/R3P.Hivemind.Core/Features/Conduit/Services/ObstacleService.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Services/ObstacleService.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Autodesk.AutoCAD.DatabaseServices;
 
-namespace R3P.Hivemind.Features.Conduit.Services
+namespace R3P.Hivemind.Core.Features.Conduit.Services
 {
-    internal static class ObstacleService
+    public static class ObstacleService
     {
         public static List<Extents3d> GetObstacles(Database db, IEnumerable<string> layerNames)
         {

--- a/R3P.Hivemind.Core/Features/Conduit/Services/ReactorService.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Services/ReactorService.cs
@@ -4,9 +4,9 @@ using AcadApp = Autodesk.AutoCAD.ApplicationServices.Application;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.EditorInput;
 
-namespace R3P.Hivemind.Features.Conduit.Services
+namespace R3P.Hivemind.Core.Features.Conduit.Services
 {
-    internal static class ReactorService
+    public static class ReactorService
     {
         private static bool _attached;
 

--- a/R3P.Hivemind.Core/Features/Conduit/Services/RouteService.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Services/RouteService.cs
@@ -5,9 +5,9 @@ using Autodesk.AutoCAD.ApplicationServices;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.Geometry;
 
-namespace R3P.Hivemind.Features.Conduit.Services
+namespace R3P.Hivemind.Core.Features.Conduit.Services
 {
-    internal static class RouteService
+    public static class RouteService
     {
         public static List<Point3d> BestOrthRoute(Point3d p1, Point3d p2)
         {

--- a/R3P.Hivemind.Core/Features/Conduit/Services/TableService.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Services/TableService.cs
@@ -4,11 +4,11 @@ using AcadApp = Autodesk.AutoCAD.ApplicationServices.Application;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.EditorInput;
 using Autodesk.AutoCAD.Geometry;
-using R3P.Hivemind.Features.Conduit.Model;
+using R3P.Hivemind.Core.Features.Conduit.Model;
 
-namespace R3P.Hivemind.Features.Conduit.Services
+namespace R3P.Hivemind.Core.Features.Conduit.Services
 {
-    internal static class TableService
+    public static class TableService
     {
         public static void InsertScheduleTable(List<ConduitItem> items)
         {

--- a/R3P.Hivemind.Core/Features/Conduit/Services/TagService.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Services/TagService.cs
@@ -1,8 +1,8 @@
 using Autodesk.AutoCAD.DatabaseServices;
 
-namespace R3P.Hivemind.Features.Conduit.Services
+namespace R3P.Hivemind.Core.Features.Conduit.Services
 {
-    internal static class TagService
+    public static class TagService
     {
         public static string NextTag(Database db, Transaction tr, ConfigService.Config cfg)
         {

--- a/R3P.Hivemind.Core/Features/Conduit/Services/TemplateService.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Services/TemplateService.cs
@@ -2,12 +2,12 @@ using System.Collections.Generic;
 using Autodesk.AutoCAD.ApplicationServices;
 using Autodesk.AutoCAD.DatabaseServices;
 
-namespace R3P.Hivemind.Features.Conduit.Services
+namespace R3P.Hivemind.Core.Features.Conduit.Services
 {
     // Drawing creator scaffolding: clones a template DWG, fills title block attributes,
     // and inserts pre-defined template content (3-line, schematics, etc.).
     // Implementation TBD per your template standards.
-    internal static class TemplateService
+    public static class TemplateService
     {
         public class DrawingSpec
         {

--- a/R3P.Hivemind.Core/Features/Conduit/Services/Utils.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Services/Utils.cs
@@ -3,9 +3,9 @@ using Autodesk.AutoCAD.ApplicationServices;
 using AcadApp = Autodesk.AutoCAD.ApplicationServices.Application;
 using Autodesk.AutoCAD.DatabaseServices;
 
-namespace R3P.Hivemind.Features.Conduit.Services
+namespace R3P.Hivemind.Core.Features.Conduit.Services
 {
-    internal static class Utils
+    public static class Utils
     {
         public static double CurveLength(Curve c) => c.GetDistanceAtParameter(c.EndParam) - c.GetDistanceAtParameter(c.StartParam);
         public static double ApplyAllowance(double len, double allowPct, double roundInc)

--- a/R3P.Hivemind.Core/R3P.Hivemind.Core.csproj
+++ b/R3P.Hivemind.Core/R3P.Hivemind.Core.csproj
@@ -6,5 +6,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Folder Include="Features\" />
+    <Folder Include="Features\Conduit\" />
+    <Folder Include="Features\Conduit\Model\" />
+    <Folder Include="Features\Conduit\Services\" />
+  </ItemGroup>
+
 </Project>
 


### PR DESCRIPTION
## Summary
- relocate the conduit model and service classes into R3P.Hivemind.Core under Features/Conduit with shared namespaces
- update the AutoCAD conduit commands and WPF UI to consume the shared core services and model types
- add the new feature folders to the core project file so the shared code is included in the build

## Testing
- dotnet build *(fails: dotnet SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd3a99f8c832c9cb9fee1615992c3