### PR TITLE
Fix conduit model namespace alias

### DIFF
--- a/R3P.Conduit/src/Features/Conduit/ConduitCommands.cs
+++ b/R3P.Conduit/src/Features/Conduit/ConduitCommands.cs
@@ -13,6 +13,7 @@ using R3P.Hivemind.Core.Features.Conduit.Services;
 using R3P.Hivemind.Features.Conduit.Services;
 using R3P.Hivemind.UI.Wpf;
 using R3P.Hivemind.Core.Diagnostics;
+using Model = R3P.Hivemind.Core.Features.Conduit.Model;
 
 namespace R3P.Hivemind.Features.Conduit
 {


### PR DESCRIPTION
## Summary
- add a namespace alias for the conduit model types so helper methods compile

## Testing
- dotnet build R3P.Conduit/R3P.Conduit.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe5e7fbd0832c8e63e4eeb541fd2a