### PR TITLE
Remove redundant Startup attribute in App.xaml

### DIFF
--- a/R3P.Hivemind.Desktop/App.xaml
+++ b/R3P.Hivemind.Desktop/App.xaml
@@ -2,8 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:R3P.Hivemind.Desktop"
-             ShutdownMode="OnMainWindowClose"
-             Startup="OnStartup">
+             ShutdownMode="OnMainWindowClose">
     <Application.Resources>
 
     </Application.Resources>


### PR DESCRIPTION
## Summary
- remove the Startup attribute from App.xaml so the Application override is used by default

## Testing
- dotnet build R3P.Hivemind.Desktop/R3P.Hivemind.Desktop.csproj *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe5e9aa3c832ca74726fbcd9c4fa3