### PR TITLE
Add global using for Conduit static helpers

### DIFF
--- a/R3P.Conduit/GlobalUsings.cs
+++ b/R3P.Conduit/GlobalUsings.cs
@@ -18,6 +18,7 @@ global using Autodesk.AutoCAD.Windows;
 
 global using R3P.Hivemind.Core.Features.Conduit.Model;
 global using R3P.Hivemind.Core.Features.Conduit.Services;
+global using R3P.Hivemind.Features.Conduit;
 global using R3P.Hivemind.Features.Conduit.Services;
 global using R3P.Hivemind.UI.Wpf;
 


### PR DESCRIPTION
## Summary
- add a global using so the Conduit project can access the R3P static class

## Testing
- dotnet build R3P.Conduit/R3P.Hivemind.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf6f178f8832cb1ec1b4446c60259