### PR TITLE
Set crash log defaults

### DIFF
--- a/R3P.Hivemind.Core/Diagnostics/CrashLogEntry.cs
+++ b/R3P.Hivemind.Core/Diagnostics/CrashLogEntry.cs
@@ -5,18 +5,19 @@ namespace R3P.Hivemind.Core.Diagnostics
     public sealed class CrashLogEntry
     {
         public DateTime TimestampUtc { get; set; }
-        public string SourcePath { get; set; }
-        public string Summary { get; set; }
-        public string FaultModule { get; set; }
-        public string ExceptionCode { get; set; }
-        public string Detail { get; set; }
+        public string SourcePath { get; set; } = string.Empty;
+        public string Summary { get; set; } = "AutoCAD crash detected";
+        public string? FaultModule { get; set; }
+        public string? ExceptionCode { get; set; }
+        public string? Detail { get; set; }
 
         public override string ToString()
         {
             var time = TimestampUtc == default ? DateTime.UtcNow : TimestampUtc;
             var module = string.IsNullOrWhiteSpace(FaultModule) ? string.Empty : $" | Module: {FaultModule}";
             var code = string.IsNullOrWhiteSpace(ExceptionCode) ? string.Empty : $" | Code: {ExceptionCode}";
-            return $"[{time:u}] {Summary ?? "AutoCAD crash detected"}{module}{code}";
+            var summary = string.IsNullOrWhiteSpace(Summary) ? "AutoCAD crash detected" : Summary;
+            return $"[{time:u}] {summary}{module}{code}";
         }
     }
 }


### PR DESCRIPTION
## Summary
- assign CrashLogEntry defaults for required fields and mark optional strings as nullable
- ensure crash log summaries fall back to a default message when blank

## Testing
- dotnet build R3P.Hivemind.Core/R3P.Hivemind.Core.csproj *(fails: `dotnet` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2af0b604832cbbc11187be5a0b9f