### PR TITLE
Set defaults for ConduitItem strings and allow nullable hint

### DIFF
--- a/R3P.Hivemind.Core/Features/Conduit/Model/ConduitItem.cs
+++ b/R3P.Hivemind.Core/Features/Conduit/Model/ConduitItem.cs
@@ -6,12 +6,12 @@ namespace R3P.Hivemind.Core.Features.Conduit.Model
     public class ConduitItem
     {
         public ObjectId Id { get; set; }
-        public string Handle { get; set; }
-        public string Tag { get; set; }
+        public string Handle { get; set; } = string.Empty;
+        public string Tag { get; set; } = string.Empty;
         public double Raw { get; set; }
         public double Adjusted { get; set; }
-        public string FtIn { get; set; }
-        public string Hint { get; set; }
+        public string FtIn { get; set; } = string.Empty;
+        public string? Hint { get; set; }
         public override string ToString()
             => $"{Tag} | {FtIn}  [{Adjusted.ToString("0.###", CultureInfo.InvariantCulture)}]  <{Handle}>" + (string.IsNullOrEmpty(Hint) ? "" : $"  ({Hint})");
     }


### PR DESCRIPTION
## Summary
- initialize ConduitItem string properties with safe defaults to honor non-null expectations
- allow the optional hint text to be null without raising warnings

## Testing
- `dotnet build R3P.Hivemind.Core/R3P.Hivemind.Core.csproj` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2af6a1e0832ca6404f8fa34870b8